### PR TITLE
Fix link to "Microsoft Azure - Web App + Database"

### DIFF
--- a/microsoft-azure-2023.01.24/icons.json
+++ b/microsoft-azure-2023.01.24/icons.json
@@ -21,7 +21,7 @@
     "icon" : "10400-icon-service-Azure-Fileshares.png"
   }, {
     "tag" : "Microsoft Azure - Web App + Database",
-    "icon" : "02515-icon-service-Web-App-+-Database.png"
+    "icon" : "02515-icon-service-Web-App-%2B-Database.png"
   }, {
     "tag" : "Microsoft Azure - Image Templates",
     "icon" : "02634-icon-service-Image-Templates.png"

--- a/microsoft-azure-2023.01.24/theme.json
+++ b/microsoft-azure-2023.01.24/theme.json
@@ -35,7 +35,7 @@
     "tag" : "Microsoft Azure - Web App + Database",
     "stroke" : "#50e6ff",
     "color" : "#50e6ff",
-    "icon" : "02515-icon-service-Web-App-+-Database.png"
+    "icon" : "02515-icon-service-Web-App-%2B-Database.png"
   }, {
     "tag" : "Microsoft Azure - Image Templates",
     "stroke" : "#5ea0ef",


### PR DESCRIPTION
The current link https://static.structurizr.com/themes/microsoft-azure-2023.01.24/02515-icon-service-Web-App-+-Database.png returns an "Access Denied" due to the unencoded "+" in the link.

The fix should produce the link https://static.structurizr.com/themes/microsoft-azure-2023.01.24/02515-icon-service-Web-App-%2B-Database.png, that serves the correct icon